### PR TITLE
Add wizard animations

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,5 @@ Players tap twice on their lap, (on web can be a 3-2-1 countdown), then choose  
 Logistics: Each countdown will be followed by a short window for player decisions (key presses). If no key press is logged for a player, or an illegal key is pressed, the player defaults to a Block. IF two players cast a spell at the same time, the spells "cancel out" and the game continues.
 
 The game is over when one player casts a spell at their opponent while the opponent is drawing mana. Also, a Kamehameha Wave defeats any opposing action (including the block and a standard spell cast).
+
+Press the **Space bar** (or the on-screen button) to start each round. The button and space bar are disabled until the round finishes. When a player wins, a full screen overlay displays the winning wizard.

--- a/index.html
+++ b/index.html
@@ -17,6 +17,50 @@
     h1 {
       margin-bottom: 20px;
     }
+    #wizards {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      width: 80%;
+      height: 120px;
+      position: relative;
+      margin-bottom: 20px;
+    }
+    .wizard {
+      width: 100px;
+      height: 100px;
+      border: 2px solid #f0f0f0;
+      background: transparent;
+    }
+    .wizard.idle { }
+    .wizard.casting { }
+    .wizard.blocking { }
+    .wizard.drawing { }
+
+    .spell {
+      position: absolute;
+      top: 40px;
+      width: 20px;
+      height: 20px;
+      border-radius: 50%;
+      background: yellow;
+      pointer-events: none;
+    }
+    .spell.kamehameha {
+      width: 40px;
+      height: 40px;
+      background: cyan;
+    }
+    @keyframes spell-right {
+      from { left: 110px; }
+      to { left: calc(100% - 120px); }
+    }
+    @keyframes spell-left {
+      from { left: calc(100% - 120px); }
+      to { left: 110px; }
+    }
+    .spell.move-right { animation: spell-right 1s linear forwards; }
+    .spell.move-left { animation: spell-left 1s linear forwards; }
     .game-log {
       width: 80%;
       max-height: 300px;
@@ -38,14 +82,27 @@
 </head>
 <body>
   <h1>Wizard Duel</h1>
+  <div id="wizards">
+    <canvas id="wizard1" class="wizard idle" width="100" height="100"></canvas>
+    <canvas id="wizard2" class="wizard idle" width="100" height="100"></canvas>
+  </div>
   <div class="status" id="mana-status"></div>
   <div class="status" id="countdown"></div>
   <div class="game-log" id="game-log"></div>
-  <button onclick="startRound()">Start Next Round</button>
+  <button id="start-button" onclick="startRound()">Start Round (Space)</button>
 
   <script>
     let mana = { p1: 1, p2: 1 };
     let actions = { p1: 'Block', p2: 'Block' };
+    let roundActive = false;
+    let gameOver = false;
+
+    document.getElementById('start-button').addEventListener('click', startRound);
+    window.addEventListener('keydown', (e) => {
+      if (e.code === 'Space' && !roundActive && !gameOver) {
+        startRound();
+      }
+    });
 
     function log(message) {
       const logDiv = document.getElementById('game-log');
@@ -57,8 +114,82 @@
       document.getElementById('mana-status').textContent = `Player 1 Mana: ${mana.p1} | Player 2 Mana: ${mana.p2}`;
     }
 
+    function drawWizard(id, state) {
+      const canvas = document.getElementById(id);
+      const ctx = canvas.getContext('2d');
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      let color = id === 'wizard1' ? '#9c27b0' : '#3f51b5';
+      if (state === 'casting') color = '#b00';
+      else if (state === 'blocking') color = '#06b';
+      else if (state === 'drawing') color = '#0b0';
+      ctx.fillStyle = color;
+      ctx.beginPath();
+      ctx.moveTo(50, 30);
+      ctx.lineTo(20, 90);
+      ctx.lineTo(80, 90);
+      ctx.closePath();
+      ctx.fill();
+      ctx.fillStyle = '#ffe0bd';
+      ctx.beginPath();
+      ctx.arc(50, 20, 10, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.fillStyle = '#000';
+      ctx.beginPath();
+      ctx.moveTo(50, 5);
+      ctx.lineTo(30, 30);
+      ctx.lineTo(70, 30);
+      ctx.closePath();
+      ctx.fill();
+    }
+
+    function setWizardState(player, state) {
+      const id = player === 'p1' ? 'wizard1' : 'wizard2';
+      document.getElementById(id).className = `wizard ${state}`;
+      drawWizard(id, state);
+    }
+
+    function spawnSpell(player, isKamehameha) {
+      const container = document.getElementById('wizards');
+      const spell = document.createElement('div');
+      spell.classList.add('spell');
+      if (isKamehameha) spell.classList.add('kamehameha');
+      spell.classList.add(player === 'p1' ? 'move-right' : 'move-left');
+      container.appendChild(spell);
+      spell.addEventListener('animationend', () => spell.remove());
+    }
+
+    function showWinner(player) {
+      const overlay = document.createElement('div');
+      overlay.style.position = 'fixed';
+      overlay.style.top = 0;
+      overlay.style.left = 0;
+      overlay.style.width = '100%';
+      overlay.style.height = '100%';
+      overlay.style.background = 'rgba(0,0,0,0.8)';
+      overlay.style.display = 'flex';
+      overlay.style.flexDirection = 'column';
+      overlay.style.alignItems = 'center';
+      overlay.style.justifyContent = 'center';
+      overlay.style.color = '#fff';
+      const title = document.createElement('h1');
+      title.textContent = player === 'p1' ? 'Player 1 Wins!' : 'Player 2 Wins!';
+      overlay.appendChild(title);
+      const canvas = document.createElement('canvas');
+      canvas.width = 100;
+      canvas.height = 100;
+      overlay.appendChild(canvas);
+      document.body.appendChild(overlay);
+      canvas.id = 'winner';
+      drawWizard('winner', 'idle');
+    }
+
     function startRound() {
+      if (roundActive || gameOver) return;
+      roundActive = true;
+      document.getElementById('start-button').disabled = true;
       actions = { p1: 'Block', p2: 'Block' }; // default if no input
+      setWizardState('p1', 'idle');
+      setWizardState('p2', 'idle');
       document.getElementById('countdown').textContent = '3...';
       setTimeout(() => document.getElementById('countdown').textContent = '2...', 500);
       setTimeout(() => document.getElementById('countdown').textContent = '1...', 1000);
@@ -74,21 +205,32 @@
 
     function handleKey(e) {
       switch(e.key) {
-        case 'w': actions.p1 = 'Draw'; break;
-        case 's': actions.p1 = 'Block'; break;
-        case 'd': if (mana.p1 > 0) { actions.p1 = 'Cast'; } break;
-        case 'a': if (mana.p1 >= 4) { actions.p1 = 'Kamehameha'; } break;
+        case 'w': actions.p1 = 'Draw'; setWizardState('p1','drawing'); break;
+        case 's': actions.p1 = 'Block'; setWizardState('p1','blocking'); break;
+        case 'd': if (mana.p1 > 0) { actions.p1 = 'Cast'; setWizardState('p1','casting'); } break;
+        case 'a': if (mana.p1 >= 4) { actions.p1 = 'Kamehameha'; setWizardState('p1','casting'); } break;
 
-        case 'ArrowUp': actions.p2 = 'Draw'; break;
-        case 'ArrowDown': actions.p2 = 'Block'; break;
-        case 'ArrowLeft': if (mana.p2 > 0) { actions.p2 = 'Cast'; } break;
-        case 'ArrowRight': if (mana.p2 >= 4) { actions.p2 = 'Kamehameha'; } break;
+        case 'ArrowUp': actions.p2 = 'Draw'; setWizardState('p2','drawing'); break;
+        case 'ArrowDown': actions.p2 = 'Block'; setWizardState('p2','blocking'); break;
+        case 'ArrowLeft': if (mana.p2 > 0) { actions.p2 = 'Cast'; setWizardState('p2','casting'); } break;
+        case 'ArrowRight': if (mana.p2 >= 4) { actions.p2 = 'Kamehameha'; setWizardState('p2','casting'); } break;
       }
     }
 
     function resolveRound() {
       log(`Player 1 chose ${actions.p1}`);
       log(`Player 2 chose ${actions.p2}`);
+
+      // apply final states
+      setWizardState('p1', actions.p1 === 'Cast' || actions.p1 === 'Kamehameha' ? 'casting' : actions.p1.toLowerCase());
+      setWizardState('p2', actions.p2 === 'Cast' || actions.p2 === 'Kamehameha' ? 'casting' : actions.p2.toLowerCase());
+
+      if (actions.p1 === 'Cast' || actions.p1 === 'Kamehameha') {
+        spawnSpell('p1', actions.p1 === 'Kamehameha');
+      }
+      if (actions.p2 === 'Cast' || actions.p2 === 'Kamehameha') {
+        spawnSpell('p2', actions.p2 === 'Kamehameha');
+      }
 
       if (actions.p1 === 'Draw') mana.p1++;
       if (actions.p2 === 'Draw') mana.p2++;
@@ -118,8 +260,17 @@
       log(result);
       updateManaStatus();
       document.getElementById('countdown').textContent = '';
+      roundActive = false;
+      if (result.includes('wins')) {
+        gameOver = true;
+        showWinner(result.includes('Player 1') ? 'p1' : 'p2');
+      } else {
+        document.getElementById('start-button').disabled = false;
+      }
     }
 
+    drawWizard('wizard1', 'idle');
+    drawWizard('wizard2', 'idle');
     updateManaStatus();
   </script>
 </body>


### PR DESCRIPTION
## Summary
- add canvas elements for wizards
- style wizards and spells
- manage wizard state classes on key input
- spawn animated spells on cast actions
- draw simple wizard sprites
- start round via space bar and disable spam
- show end screen for winner

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68409e744fc48331a49a46670568b60e